### PR TITLE
reorganize file structure, add dev tools, and renamed extension

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/popup.jsx"></script>
   </body>
 </html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,13 +1,13 @@
 {
-    "name": "PlaceHolder",
-    "description": "Basic PlaceHolder React Extension for forking and building on",
+    "name": "JS-Toolkit",
+    "description": "Currently for parsing endpoints and downloading js files into a merged file",
     "version": "0.1",
-    "author": "Lordcat, 2024",
+    "author": "Lordcat & mrunoriginal/AtlasWiki, 2024",
     "manifest_version": 3,
     "devtools_page": "devtools.html",
     "action": {
       "default_popup": "index.html",
-      "default_title": "Placeholder React extension"
+      "default_title": "JS Toolkit for Hackers"
     },
     "content_security_policy": {
       "extension_pages": "script-src 'self'; object-src 'self'"

--- a/src/DevTool/DevtoolsApp.tsx
+++ b/src/DevTool/DevtoolsApp.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
+import PopUpApp from '../PopUp/PopUpApp'
+import "../App.css"
+
 
 function DevToolsApp() {
   return (
     <div className="p-4">
-      <h1 className="text-2xl mb-4">DevTools Panel</h1>
-      <p>This is a placeholder for the DevTools panel.</p>
+      <PopUpApp />
     </div>
   )
 }

--- a/src/PopUp/PopUpApp.jsx
+++ b/src/PopUp/PopUpApp.jsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 
-import './App.css'
+import '../App.css'
 
 function PopUpApp() {
   return (

--- a/src/PopUp/routes/js-files.jsx
+++ b/src/PopUp/routes/js-files.jsx
@@ -1,4 +1,4 @@
-import { NavBar } from '../components/navbar'
+import { NavBar } from '../../components/navbar'
 
 export function JSFiles(){
     return(

--- a/src/PopUp/routes/urls.jsx
+++ b/src/PopUp/routes/urls.jsx
@@ -1,4 +1,4 @@
-import { NavBar } from '../components/navbar'
+import { NavBar } from '../../components/navbar'
 export function URLS(){
     return(
         <div>

--- a/src/devtools.tsx
+++ b/src/devtools.tsx
@@ -1,11 +1,21 @@
 /// <reference types="chrome"/>
 
+
+import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import DevToolsApp from './DevtoolsApp'
+import DevToolsApp from './DevTool/DevtoolsApp'
+import { URLS } from './PopUp/routes/urls'
+import { JSFiles } from './PopUp/routes/js-files'
+import {
+  HashRouter as Router,
+  Route,
+  Routes,
+} from 'react-router-dom'
 import React from 'react';
+import "./index.css"
 
 chrome.devtools.panels.create(
-  "Placeholder Extension",
+  "JS-Toolkit",
   "",
   "devtools.html",  // Change this from "devtools.tsx" to "devtools.html"
   (panel) => {
@@ -15,7 +25,16 @@ chrome.devtools.panels.create(
       const root = panelWindow.document.getElementById('root');
       if (root && !root.hasChildNodes()) {
         console.log("Root element found, rendering React component");
-        createRoot(root).render(<DevToolsApp />);
+        createRoot(root).render(
+          <StrictMode>
+          <Router>
+            <Routes>
+              <Route path="" element={<DevToolsApp />} />
+              <Route path="urls" element={<URLS />} />
+              <Route path="js-files" element={<JSFiles />} />
+            </Routes>
+          </Router>
+        </StrictMode>);
       } else {
         console.log("Root element not found or already has children");
       }

--- a/src/popup.jsx
+++ b/src/popup.jsx
@@ -5,9 +5,9 @@ import {
   Route,
   Routes,
 } from 'react-router-dom'
-import PopUpApp from './PopUpApp'
-import { URLS } from './routes/urls'
-import { JSFiles } from './routes/js-files' 
+import PopUpApp from './PopUp/PopUpApp'
+import { URLS } from './PopUp/routes/urls'
+import { JSFiles } from './PopUp/routes/js-files' 
 import './index.css'
 
 createRoot(document.getElementById('root')).render(

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}', './devtools.html'],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
The file structure now follows the template from https://github.com/LordCat/PlaceHolder-Extension

devtools is now visible and matches from the popup UI. File names have been renamed to fit in with the reorganization as well as directory restructuring.